### PR TITLE
Add new part endponts

### DIFF
--- a/parts_api/api/serializers.py
+++ b/parts_api/api/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from parts_api import models
+
+
+class PartSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Part
+        fields = "__all__"

--- a/parts_api/api/viewsets.py
+++ b/parts_api/api/viewsets.py
@@ -1,0 +1,8 @@
+from rest_framework import viewsets
+from parts_api.api import serializers
+from parts_api import models
+
+
+class PartViewSet(viewsets.ModelViewSet):
+    serializer_class = serializers.PartSerializer
+    queryset = models.Part.objects.all()

--- a/parts_api/models.py
+++ b/parts_api/models.py
@@ -1,3 +1,16 @@
 from django.db import models
 
 # Create your models here.
+
+
+class Part(models.Model):
+
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(max_length=255)
+    sku = models.CharField(max_length=255)
+    description = models.CharField(max_length=255)
+    weight_ounces = models.IntegerField()
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        db_table = "part"

--- a/parts_api/tests/test_part.py
+++ b/parts_api/tests/test_part.py
@@ -1,11 +1,16 @@
 from django.test import TestCase, Client
 from django.db import connection
 from contextlib import closing
+from rest_framework import status
 
 import json
 
+from parts_api.models import Part
+from parts_api.api.serializers import PartSerializer
+
 from parts_api import views
 from parts_api.tests.utils import HttpRequest, HttpResponse
+
 
 # connection = sqlite3.connect("db.sqlite3", check_same_thread=False)
 
@@ -43,7 +48,7 @@ class PartViewTests(TestCase):
                 """INSERT INTO part VALUES (4, "{}", "{}", "{}", {}, {}) \
                             """.format(self.stub_part["name"], self.stub_part["sku"], self.stub_part["description"],
                                        self.stub_part["weight_ounces"], self.stub_part["is_active"])
-                )
+            )
 
     def get_part(self, part_id):
         with closing(self.connection.cursor()) as cursor:
@@ -53,3 +58,122 @@ class PartViewTests(TestCase):
                 ))
             part = cursor.fetchall()
         return part[0]
+
+
+class PartViewV2Tests(TestCase):
+    """ Test class for the new Part endpoint using DRF """
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_get_all_parts(self):
+        all_parts = Part.objects.all()
+        serializer = PartSerializer(all_parts, many=True)
+
+        response = self.client.get("/part/v2/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_get_part_by_id(self):
+        part = Part.objects.get(id=1)
+
+        response = self.client.get("/part/v2/1/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], part.id)
+        self.assertEqual(response.data["name"], part.name)
+
+    def test_add_part(self):
+        payload = {"name": "part name", "sku": "part sku", "description": "part description", "weight_ounces": 7,
+                   "is_active": 1}
+
+        response = self.client.post("/part/v2/", json.dumps(payload), content_type='application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], payload["name"])
+        self.assertEqual(response.data["description"], payload["description"])
+
+    def test_add_invalid_part(self):
+        payload = {"name": "part name"}
+
+        response = self.client.post("/part/v2/", json.dumps(payload), content_type='application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_part(self):
+        payload = {"name": "part name", "sku": "part sku", "description": "part description", "weight_ounces": 7,
+                   "is_active": 1}
+
+        response = self.client.post("/part/v2/", json.dumps(payload), content_type='application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], payload["name"])
+        self.assertEqual(response.data["description"], payload["description"])
+
+        updated_payload = {"name": "part name 2", "sku": "part sku", "description": "part description",
+                           "weight_ounces": 7, "is_active": 1}
+
+        created_part_id = response.data["id"]
+
+        response = self.client.put("/part/v2/{}/".format(created_part_id), json.dumps(updated_payload),
+                                   content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], updated_payload["name"])
+        self.assertEqual(response.data["description"], updated_payload["description"])
+
+    def test_update_part_missing_attribute(self):
+        payload = {"name": "part name", "sku": "part sku", "description": "part description", "weight_ounces": 7,
+                   "is_active": 1}
+
+        response = self.client.post("/part/v2/", json.dumps(payload), content_type='application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], payload["name"])
+        self.assertEqual(response.data["description"], payload["description"])
+
+        updated_payload = {"name": "part name 2"}
+
+        created_part_id = response.data["id"]
+
+        response = self.client.put("/part/v2/{}/".format(created_part_id), json.dumps(updated_payload),
+                                   content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_part(self):
+        payload = {"name": "part name", "sku": "part sku", "description": "part description", "weight_ounces": 7,
+                   "is_active": 1}
+
+        response = self.client.post("/part/v2/", json.dumps(payload), content_type='application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], payload["name"])
+        self.assertEqual(response.data["description"], payload["description"])
+
+        created_part_id = response.data["id"]
+
+        response = self.client.delete("/part/v2/{}/".format(created_part_id))
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_missing_part(self):
+        response = self.client.delete("/part/v2/{}/".format(99))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_patch_part(self):
+        payload = {"name": "part name", "sku": "part sku", "description": "part description", "weight_ounces": 7,
+                   "is_active": 1}
+
+        response = self.client.post("/part/v2/", json.dumps(payload), content_type='application/json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["name"], payload["name"])
+        self.assertEqual(response.data["description"], payload["description"])
+
+        updated_payload = {"name": "part name 2"}
+
+        created_part_id = response.data["id"]
+
+        response = self.client.patch("/part/v2/{}/".format(created_part_id), json.dumps(updated_payload),
+                                     content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], updated_payload["name"])

--- a/parts_api/urls.py
+++ b/parts_api/urls.py
@@ -2,11 +2,18 @@ from django.contrib import admin
 from django.conf.urls import include, url
 from parts_api import views
 
+from rest_framework import routers
+from parts_api.api import viewsets as part_view_sets
+
+route = routers.DefaultRouter()
+
+route.register("v2", part_view_sets.PartViewSet, basename="Part")
+
 # I had to change the urls order because when the one with empty path was in the first position
 # the other endpoints were not being loaded
 urlpatterns = [
     url("admin/", admin.site.urls),
     url("part/update/(?P<part_id>\d+)/$", views.update_part),
+    url("part/", include(route.urls)),
     url("", views.home, name="home"),
 ]
-


### PR DESCRIPTION
This PR adds the new part crud. The new endpoints are:

- /part/v2/  - GET - List all parts
- /part/v2/ - POST - Add a new part
- /part/v2/{id}/ - GET, PUT, PATCH, DELETE - Get by id, update the whole part, update part of the part and delete part
- Add unit tests